### PR TITLE
Pin MongoDB to 3.6.1

### DIFF
--- a/builds/mongo/Dockerfile
+++ b/builds/mongo/Dockerfile
@@ -1,5 +1,5 @@
 # Build a docker container containing a mongodb
-FROM mongo:latest
+FROM mongo:3.6.1
 MAINTAINER Rémi GATTAZ <remi.gattaz@gmail.com>
 
 ADD run.sh /run.sh

--- a/builds/mongo/run.sh
+++ b/builds/mongo/run.sh
@@ -4,7 +4,7 @@ set -m
 
 
 # Start mongodb
-mongod --smallfiles --auth &
+mongod --smallfiles --auth --bind_ip_all &
 
 # Wait for mongodb to startup
 RET=1


### PR DESCRIPTION
Using the latest version of MongoDB in docker won't work with the current configuration. If you use the environment as is, you will get the following error when you start the sails application:
```
error: Error: Failed to connect to MongoDB.  Are you sure your configured Mongo instance is running?
```

This issue was created because a default behavior changed between the latest version we were using (3.4) and the currently latest version (3.6). This change is documented here: https://docs.mongodb.com/manual/release-notes/3.6-compatibility/#bind-ip-compatibility

In the version 3.4, by default MongoDB is binding on the address `0.0.0.0`. Without any extra configuration, the service is therefore immediately accessible from outside the container. In the version 3.6, by default the service is however only binding on the address `127.0.0.1`. It is therefore not accessible from outside the docker container and the service can only be reached from inside the container. This is why it raises the error mentioned at the beginning of this PR.

Using the flag `--bind_all_ip` will enforce the service to bind all interfaces and the service will then be available from outside the container again 🎉

I also took the opportunity to pin the version number of MongoDB to avoid running into a similar "version problem" in the future 😄 

@Antoine38660 a little PR just for you :-)